### PR TITLE
Make hogan_assets play nice with sprockets-rails >= 3

### DIFF
--- a/lib/hogan_assets/engine.rb
+++ b/lib/hogan_assets/engine.rb
@@ -1,10 +1,11 @@
 module HoganAssets
   class Engine < ::Rails::Engine
-    initializer "sprockets.hogan", :after => "sprockets.environment", :group => :all do |app|
-      next unless app.assets
+    initializer "sprockets.hogan", :group => :all do |app|
       HoganAssets::Config.load_yml! if HoganAssets::Config.yml_exists?
-      HoganAssets::Config.template_extensions.each do |ext|
-        app.assets.register_engine(".#{ext}", Tilt)
+      Rails.application.config.assets.configure do |env|
+        HoganAssets::Config.template_extensions.each do |ext|
+          env.register_engine(".#{ext}", Tilt)
+        end
       end
     end
   end


### PR DESCRIPTION
**Issue**
The `HoganTemplates` object is not getting created (The configuration block needs to be used when working with sprockets-rails >= 3.)

https://github.com/rails/sprockets-rails/issues/292
https://github.com/leshill/hogan_assets/issues/26

**Changes**
Moving register_engine to a configuration block.